### PR TITLE
Allow builder greater than 3.0

### DIFF
--- a/akamai_api.gemspec
+++ b/akamai_api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'active_support', '>= 2'
   gem.add_dependency 'thor',           '~> 0.14.0'
   gem.add_dependency 'savon',          '~> 1.2.0'
-  gem.add_dependency 'builder',        '~> 3.1.3'
+  gem.add_dependency 'builder',        '~> 3.0'
 
   gem.add_development_dependency 'rspec', '~> 2.11'
   gem.add_development_dependency 'savon_spec', '~> 1.3'


### PR DESCRIPTION
Specs are passing correctly with 3.0.0 also.
