### PR TITLE
fix for active support require issue

### DIFF
--- a/bin/akamai_api
+++ b/bin/akamai_api
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'active_support'
 require 'active_support/core_ext'
 require 'akamai_api'
 require 'akamai_api/cli'


### PR DESCRIPTION
Running into "uninitialized constant ActiveSupport::Autoload
(NameError)," error, was resolved by adding this require statement. The
issue is described in more detail here:
https://github.com/rails/rails/issues/14664
