### PR TITLE
add poll option to ccu arl invalidate

### DIFF
--- a/lib/akamai_api/cli/ccu/arl.rb
+++ b/lib/akamai_api/cli/ccu/arl.rb
@@ -36,26 +36,29 @@ module AkamaiApi::CLI::CCU
         raise 'You should provide at least one valid URL' if arls.blank?
         load_config
         res = AkamaiApi::CCU.purge type, :arl, arls, :domain => options[:domain]
+        puts PurgeRenderer.new(res).render
 
         if options[:poll] == true && res.code == 201
-          puts PurgeRenderer.new(res).render
-          if res.time_to_wait
-            status = AkamaiApi::CCU.status res.uri
-            while status.completed_at.nil?
-              puts StatusRenderer.new(status).render
-              sleep 60
-              status = AkamaiApi::CCU.status res.uri
-            end
-
-            puts StatusRenderer.new(status).render
-          end
-        else
-          puts PurgeRenderer.new(res).render
+          poll_status res
         end
       rescue AkamaiApi::CCU::Error
         puts StatusRenderer.new($!).render_error
       rescue AkamaiApi::Unauthorized
         puts 'Your login credentials are invalid.'
+      end
+    end
+
+    no_commands do 
+      def poll_status purge_response
+        if purge_response.time_to_wait
+          status = AkamaiApi::CCU.status purge_response.uri
+          while status.completed_at.nil?
+            puts StatusRenderer.new(status).render
+            sleep 60
+            status = AkamaiApi::CCU.status purge_response.uri
+          end
+        end
+        puts StatusRenderer.new(status).render
       end
     end
   end

--- a/spec/lib/akamai_api/cli/ccu/arl_spec.rb
+++ b/spec/lib/akamai_api/cli/ccu/arl_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+module AkamaiApi
+  describe CLI::CCU::Arl do
+    describe 'invalidate' do
+      it 'polls for status' do
+        arl = CLI::CCU::Arl.new
+
+        allow(arl).to receive(:load_config)
+        allow(arl).to receive(:options).and_return({:poll => true})
+
+        res = double()
+        expect(CCU).to receive(:purge).and_return(res)
+        
+        expect(res).to receive(:code).and_return(201)  
+        expect(res).to receive(:time_to_wait).and_return(true)
+
+        renderer = double()
+        allow(renderer).to receive(:render)
+        allow(CLI::CCU::PurgeRenderer).to receive(:new).and_return(renderer)
+
+        status_res1 = double()
+        allow(status_res1).to receive(:code).and_return(201)
+
+        status_res2 = double()
+        allow(status_res2).to receive(:completed_at).and_return(nil, nil, true)
+
+        allow(CLI::CCU::StatusRenderer).to receive(:new).and_return(renderer)
+
+        allow(res).to receive(:uri).and_return("status_uri")
+      
+        expect(CCU).to receive(:status).exactly(3).times.with("status_uri").and_return(status_res2)
+
+        expect(arl).to receive(:sleep).exactly(2).times.with(60)
+
+        arl.invalidate("test_uri")
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added a poll option to ccu arl invalidate. This feature goes ahead and polls for the status of the ```ccu arl invalidate``` request every 60 seconds and exits when it sees that purge request is successful. 

We will be using this feature in our build system. 