### PR TITLE
loosen savon dependency

### DIFF
--- a/akamai_api.gemspec
+++ b/akamai_api.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'httparty',       '~> 0.13.1'
   gem.add_dependency 'activesupport',  '>= 2.3.9',  '< 5.0'
   gem.add_dependency 'thor',           '>= 0.14.0', '< 2.0'
-  gem.add_dependency 'savon',          '~> 2.5.0'
+  gem.add_dependency 'savon',          '~> 2.5'
   gem.add_dependency 'builder',        '~> 3.0'
 end


### PR DESCRIPTION
Previously this project required savon 2.5.x , which at this point is over a year old.  The current version of savon is 2.11.1.

The project worked with no changes required with savon 2.6 and 2.7.  A small change was required to make it work with savon 2.8–2.11:  timestamps were coming through as DateTime objects rather than as iso8601 strings, so the `get_if_string` method in this project was returning nil for any timestamps.

I altered `get_if_string` to be called `get_if_handleable` and expanded it to work with DateTime objects as well as strings.