### PR TITLE
Update gemspec to require Ruby 2.2.2+ in order to support Rails 5 and activesupport

### DIFF
--- a/akamai_api.gemspec
+++ b/akamai_api.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
-  gem.required_ruby_version = Gem::Requirement.new(">= 1.9.2")
+  gem.required_ruby_version = Gem::Requirement.new(">= 2.2.2")
 
   gem.add_dependency 'httparty',       '~> 0.13.1'
-  gem.add_dependency 'activesupport',  '>= 2.3.9',  '< 5.0'
+  gem.add_dependency 'activesupport',  '>= 2.3.9'
   gem.add_dependency 'thor',           '>= 0.14.0', '< 2.0'
   gem.add_dependency 'savon',          '~> 2.5'
   gem.add_dependency 'builder',        '~> 3.0'


### PR DESCRIPTION
In order to co-exist alongside Rails 5 I had to update the gemspec to allow for activesupport versions of 5+ and bump the required Ruby version to 2.2.2 or higher.

Everything checks out locally and via Travis AFAICT.